### PR TITLE
[test] remove deploy scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Intended to discourage local deployment to gh-pages, so that deployment can be controlled via PRs and merging to main.