### PR TITLE
adjust instagram head position to be more responsive

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,15 +1,28 @@
 .headerWrapper {
+  align-items: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  margin-top: -2rem;
 }
 
 .instagram {
   top: 100;
   position: absolute;
-  right: 0;
+  right: 30vw;
   padding: 1rem;
   transform: translateY(3rem);
+}
+
+@media (max-width: 1200px) {
+  .instagram {
+    right: 10vw;
+  }
+}
+
+@media (max-width: 575px) {
+  .instagram {
+    right: 0;
+  }
 }
 
 .header {


### PR DESCRIPTION
- Noticed that the IG logo would push to the far right with wide viewports.
- Added media queries to better position the logo near the top-right of the hero image across a variety of viewport widths