### PR TITLE
fix ptag errors with rowIcons and rowImgText

### DIFF
--- a/src/components/Rows/RowIcons/RowIcons.jsx
+++ b/src/components/Rows/RowIcons/RowIcons.jsx
@@ -14,9 +14,9 @@ const injectMotionIcon = (icon) => {
       <h5>
         { spanMap(icon.heading) }
       </h5>
-      <p className='fw-lighter'>
+      <div className='fw-lighter'>
         { spanMap(icon.text) }
-      </p>
+      </div>
     </motion.div>
   )
 }

--- a/src/components/Rows/RowImgText/RowImgText.jsx
+++ b/src/components/Rows/RowImgText/RowImgText.jsx
@@ -10,9 +10,9 @@ const RowImgText = ({img, alt, heading, text, imgRight}) => {
           <h4 className={`fw-light`}>
             { spanMap(heading) }
             </h4>
-          <p className={`fw-lighter`}>
+          <div className={`fw-lighter`}>
             { spanMap(text) }
-          </p>
+          </div>
         </div>
         <motion.div
           className={`col-sm-5`}
@@ -39,9 +39,9 @@ const RowImgText = ({img, alt, heading, text, imgRight}) => {
         <h4 className={`fw-light`}>
           { spanMap(heading) }
         </h4>
-        <p className={`fw-lighter`}>
+        <div className={`fw-lighter`}>
           { spanMap(text) }
-        </p>
+        </div>
       </div>
     </div>
   )

--- a/src/components/Rows/RowImgText/RowImgText.module.css
+++ b/src/components/Rows/RowImgText/RowImgText.module.css
@@ -1,6 +1,7 @@
 .row {
   display: flex;
   justify-content: center;
-  margin-block: 4rem;
+  align-items: center;
+  margin-block: 6rem;
   max-width: 1200px;
 }


### PR DESCRIPTION
- Changed RowIcons and RowImgText `<p>` to `<div>`
- Added styling to better center images in RowImgText when:
  - Text height exceeds image height at medium viewport width

Before:
<img width="619" alt="Screen Shot 2022-10-13 at 11 00 33 AM" src="https://user-images.githubusercontent.com/96446064/195633321-dbcbf81a-caa0-4c14-aa3b-17bd6a461dfd.png">

After:
<img width="628" alt="Screen Shot 2022-10-13 at 11 00 43 AM" src="https://user-images.githubusercontent.com/96446064/195633333-6edc1674-227c-4134-9bbb-31f6b8e9b1c6.png">

Original error message:
<img width="664" alt="Screen Shot 2022-10-13 at 10 17 43 AM" src="https://user-images.githubusercontent.com/96446064/195633595-aa0faaf5-f8a4-4adc-8117-9b823457ce2f.png">
