### PR TITLE
fix/Header jim rohn cite font styles

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -15,7 +15,7 @@ const Header = () => {
       <div className={`${styles.header} textRed`}>
         <div className={`${styles.wrapper} col-8 col-sm-6`}>
           <h1 className={`${styles.h1}`}><span className={`${styles.dk}`}>DK</span><span className={`${styles.dojo}`}>Dojo</span></h1>
-          <h4 className={`${styles.h4}`}>“You can either suffer the pain of discipline or the pain of regret.” -Jim Rohn</h4>
+          <h4 className={`${styles.h4}`}>“You can either suffer the pain of discipline or the pain of regret.” <span className={`${styles.cite}`}> -Jim Rohn</span></h4>
           <h6 className={`${styles.h6}`}>Stay disciplined. Stay true. Attack with consistent persistency.</h6>
           <button onClick={() => scrollToForm()} className={`${styles.button}`}>GET RESULTS</button>
         </div>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -58,6 +58,12 @@
   margin: 2rem 0 1rem 2rem;
 }
 
+.cite {
+  font-size: 1rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
 .h6 {
   font-style: italic;
   font-weight: 100;


### PR DESCRIPTION

- In the Header component, noticed the `-Jim Rohn` cite line would break between `-` and `J`
- Fixed by adding wrapping in `<span>` and adding some css

<details>
<summary>See screenshots for details.</summary>

Before
![Screen Shot 2023-01-16 at 10 43 35 AM](https://user-images.githubusercontent.com/96446064/212717690-249c9076-df0c-4c15-83ae-6d064df4a75f.png)

After
![Screen Shot 2023-01-16 at 10 43 39 AM](https://user-images.githubusercontent.com/96446064/212717702-cd8c9b2a-b4b8-4e3f-aca3-cfc9997f7db1.png)
</details>